### PR TITLE
don't use broken CS50

### DIFF
--- a/finance/.cs50.yml
+++ b/finance/.cs50.yml
@@ -1,6 +1,7 @@
 check50:
   dependencies:
     - flask_session
+    - cs50==5.0.0
   files: &check50_files
     - !exclude "*.pyc"
     - !exclude __pycache__


### PR DESCRIPTION
cs50 versie 5.0.1 is twee dagen geleden uitgekomen. Deze versie sloopt de wijze waarop binnen finance de database wordt benaderd. Dit zorgt voor 500 errors met cryptische logberichten. Gevonden naar aanleiding van vragen van een student WebIK bij wie de checks opeens niet meer werkten, ondanks dat er geen wijzigingen in de code waren doorgevoerd.

Deze wijzing forceert tijdelijk het gebruik van de oude, wel werkende, versie 5.0.0.