### PR TITLE
Update crack.adoc

### DIFF
--- a/crack/crack.adoc
+++ b/crack/crack.adoc
@@ -93,12 +93,11 @@ Be sure to read up on `crypt`, taking particular note of its mention of "salt":
 man crypt
 ----
 
-Per that man page, you'll likely want to put
+You'll likely want to put
 
 [source,c]
 ----
-#define _XOPEN_SOURCE
-#include <unistd.h>
+#include <crypt.h>
 ----
 
 at the top of your file in order to use `crypt`.


### PR DESCRIPTION
```
#include <crypt.h>
```

Haalt de functie `crypt` nu ook binnen. Dit gebruikt cs50 nu zelf ook.

Lost het niet vinden van crypt op, want zo ver ik begrijp is de header van `crypt` verplaatst uit `unistd.h`. Alternatief is 

```
#define _GNU_SOURCE
```

ipv 

```
#define _XOPEN_SOURCE
```